### PR TITLE
Update renconstruct example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ This is an optional method that, if given, will cause `renconstruct` to execute 
 ### Build a set of distributions
 
 ```bash
-renconstruct build -~/my-project out/ -c my-config.toml
+renconstruct build -c my-config.toml ~/my-project out/
 ```
 
 ## renotize


### PR DESCRIPTION
renconstruct expects options to come first, before the input and output directory, per its help message:

Usage: renconstruct build [OPTIONS] <INPUT_DIR> <OUTPUT_DIR>

However, the example in the README has it placed after the directories instead, which doesn't seem to work.
This PR updates the example.